### PR TITLE
Add Brave to list of default browsers

### DIFF
--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -1522,6 +1522,7 @@
                                                 <menu key="menu" title="OtherViews" id="585">
                                                     <items>
                                                         <menuItem title="Safari" state="on" id="586"/>
+                                                        <menuItem title="Brave" id="1528"/>
                                                         <menuItem title="Chrome" id="1529"/>
                                                         <menuItem title="Microsoft Edge" id="5wj-Ph-3C9">
                                                             <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
Thanks @skovatch for addressing https://github.com/Ascoware/get-iplayer-automator/issues/348, but there was not actually a way to select **Brave** as the default browser.

Please let me know if you would like any changes.